### PR TITLE
Support android plugin

### DIFF
--- a/src/main/groovy/com/github/youribonnaffe/gradle/format/FormatTask.groovy
+++ b/src/main/groovy/com/github/youribonnaffe/gradle/format/FormatTask.groovy
@@ -17,13 +17,23 @@ public class FormatTask extends DefaultTask {
     def List<String> importsOrder
     def File importsOrderConfigurationFile
 
+    void addFiles(File file, List<File> files) {
+        file.eachFileRecurse {
+            if (it.name =~ /.*\.java/) files.add(it);
+        }
+    }
+
     @TaskAction
     void format() {
-        if (files?.isEmpty()) {
+        if (!files) {
             if (project.plugins.hasPlugin(JavaPlugin)) {
                 files = project.sourceSets.main.java + project.sourceSets.test.java
             } else if (project.plugins.hasPlugin("android")) {
-                files = project.android.sourceSets.main.java + project.android.sourceSets.test.java
+                final ArrayList list = []
+                project.android.sourceSets.main.java.srcDirs.each { folder ->
+                    addFiles(folder, list)
+                }
+                files = project.files(list)
             }
         }
 


### PR DESCRIPTION
This PR is related to #17 
I tried your changes but they didn't work, so I started digging. It seems that the android plugin follows the same structure as the java plugin, but the sourceSets are implemented with different [classes](https://android.googlesource.com/platform/tools/build/+/master/gradle/src/main/groovy/com/android/build/gradle/internal/api/DefaultAndroidSourceSet.java). 
It seems necessary to manually walk through all the android directories to collect the files to be formatted.
This is my first time working with groovy and gradle plugins, so I could've easily done something awful in the code. 